### PR TITLE
BUG: Clear ignored exceptions correctly in PyArray_FromInterface()

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2161,6 +2161,7 @@ PyArray_FromInterface(PyObject *origin)
                     Py_TYPE(origin), "__array_interface__") < 0) {
                 return NULL;
             }
+            PyErr_Clear();
         }
         return Py_NotImplemented;
     }


### PR DESCRIPTION
In PyArray_FromInterface, properly clear exceptions when they aren't supposed to be raised. Leaving the exception set can cause confusing problems later (e.g. with PyDict_GetItem), or assertion errors (when building with assertions enabled).

